### PR TITLE
feat: optimize headings for Pagefind indexing & add scroll-to-top button

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -44,6 +44,8 @@
     <link rel="stylesheet" href="/assets/css/style.css"/>
     <link href="/pagefind/pagefind-ui.css" rel="stylesheet"/>
     <link rel="stylesheet" href="/assets/css/icons.css" />
+    <link rel="stylesheet" href="/assets/css/scroll-top.css" />
+
 
     {% include "partials/og-meta.njk" %}
     {% include "partials/twitter-meta.njk"
@@ -55,6 +57,14 @@
       {% block content %}{% endblock %}
     </main>
     {% include "partials/footer.njk" %}
+
+    <button id="scrollTop" class="scroll-top" aria-label="Наверх">
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <line x1="12" y1="19" x2="12" y2="5"></line>
+        <polyline points="5 12 12 5 19 12"></polyline>
+      </svg>
+    </button>
+
     {# JS Scripts #}
     <script src="/pagefind/pagefind-ui.js"></script>
     <script>
@@ -64,6 +74,7 @@
     </script>
     <script src="{{ '/assets/js/nav-toggle.js' | url }}"></script>
     <script src="/assets/js/icons.js" defer></script>
+    <script src="/assets/js/scrolltop.js" defer></script>
     <script src="https://unpkg.com/website-carbon-badges@1.1.3/b.min.js" defer></script>
   </body>
 </html>

--- a/src/_includes/partials/contacts.njk
+++ b/src/_includes/partials/contacts.njk
@@ -1,5 +1,5 @@
 <section id="contacts">
-  <h3>Контакты</h3>
+  <h3 id="cv-contacts">Контакты</h3>
 
   <ul>
     {% for contact in social.contacts %}

--- a/src/_includes/partials/description.njk
+++ b/src/_includes/partials/description.njk
@@ -1,5 +1,5 @@
 <section id="description" itemscope itemtype="https://schema.org/Person">
-  <h3>Обо мне</h3>
+  <h3 id="cv-description">Обо мне</h3>
 
   <!-- Basic Data -->
   <ul class="person-details">

--- a/src/_includes/partials/education.njk
+++ b/src/_includes/partials/education.njk
@@ -1,5 +1,5 @@
 <section id="education">
-    <h3>Образование</h3>
+    <h3 id="cv-education">Образование</h3>
     <dl itemprop="alumniOf" itemscope itemtype="http://schema.org/EducationalOrganization">
         <dt>
         <strong class="organization-name" itemprop="name">

--- a/src/_includes/partials/expirience.njk
+++ b/src/_includes/partials/expirience.njk
@@ -1,5 +1,5 @@
 <section id="expirience">
-<h3>Опыт работы</h3>
+<h3 id="cv-expirience">Опыт работы</h3>
 <dl>
     <dt itemscope itemtype="http://schema.org/Role">
         <div itemprop="worksFor" itemscope itemtype="http://schema.org/Organization">

--- a/src/assets/css/scroll-top.css
+++ b/src/assets/css/scroll-top.css
@@ -1,0 +1,26 @@
+.scroll-top {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  display: none;
+  background-color: #a0a0a0;
+  border: none;
+  border-radius: 50%;
+  width: 3rem;
+  height: 3rem;
+  font-size: 1.5rem;
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+  z-index: 1000;
+  transition: opacity 0.3s, transform 0.3s;
+}
+
+.scroll-top.show {
+  display: block;
+  transform: translateY(0);
+}
+
+.scroll-top:hover {
+  background-color: #e0a800;
+  transform: translateY(-2px);
+}

--- a/src/assets/js/scrolltop.js
+++ b/src/assets/js/scrolltop.js
@@ -1,0 +1,28 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const scrollBtn = document.createElement("button");
+  scrollBtn.id = "scrollTop";
+  scrollBtn.className = "scroll-top";
+  scrollBtn.setAttribute("aria-label", "Наверх");
+  scrollBtn.innerHTML = `
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <line x1="12" y1="19" x2="12" y2="5"></line>
+      <polyline points="5 12 12 5 19 12"></polyline>
+    </svg>
+  `;
+  document.body.appendChild(scrollBtn);
+
+  window.addEventListener("scroll", () => {
+    if (window.scrollY > 300) {
+      scrollBtn.classList.add("show");
+    } else {
+      scrollBtn.classList.remove("show");
+    }
+  });
+
+  scrollBtn.addEventListener("click", () => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  });
+});


### PR DESCRIPTION
- Add unique ids to headings (h3) for proper Pagefind sub-result linking.
- Add 'Наверх' button with refined curved SVG arrow.
- Create scroll-top.css for styling and scrolltop.js for smooth scroll behavior.
- Update relevant partials to include scroll button markup.